### PR TITLE
add S3 region support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -qqy update && \
   apt-get -qqy clean && \
   pip install s3cmd
 
-ENV ACCESS_KEY="" SECRET_KEY="" BUCKET="" DBS=""
+ENV ACCESS_KEY="" SECRET_KEY="" BUCKET="" DBS="" REGION="us-east-1"
 
 ENV CRON_D_BACKUP="0 1,9,17    * * * root   /backup.sh | logger\n"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ optionally the prefix to store the backups in.
 You *must* specify the bucket (and prefix) with the `s3:` scheme and trailing
 slash; e.g. `s3://some-bucket/` or `s3://some-bucket/some-prefix/`.
 
+By default, the S3 region used is `us-east-1`.
+You can override it  with the REGION environment variable.
+See [the official amazon region names](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) for more informations.
+
 See docker-compose.yml for an example of configuration.
 
 # Usage

--- a/backup.sh
+++ b/backup.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Upload the backups to S3 --region=$REGION
-s3cmd --access_key=$ACCESS_KEY --secret_key=$SECRET_KEY sync $DIR/ $BUCKET
+s3cmd --access_key=$ACCESS_KEY --secret_key=$SECRET_KEY --region=$REGION sync $DIR/ $BUCKET
 
 # Clean up
 rm -rf $DIR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ backup:
     BUCKET: s3://BUCKET/[PREFIX/]
     ACCESS_KEY: KEY
     SECRET_KEY: SECRET
+    REGION: eu-central-1
     DBS: DB_NAME
     CRON_D_BACKUP: |
       # Run at strange (UTC) hours, (14,22,06 NZDT, 13,21,05 NZST)

--- a/restore.sh
+++ b/restore.sh
@@ -11,13 +11,13 @@ set -e
 # Check that a backup is specified or list all backups!
 if [ -z "$1" ]
 then
-	s3cmd --access_key=$ACCESS_KEY --secret_key=$SECRET_KEY ls $BUCKET
+	s3cmd --access_key=$ACCESS_KEY --secret_key=$SECRET_KEY --region=$REGION ls $BUCKET
 else
 	# Create a temporary directory to hold the backup files
 	DIR=$(mktemp -d)
 
 	# Get the backups from S3
-	s3cmd --access_key=$ACCESS_KEY --secret_key=$SECRET_KEY get $BUCKET$1 $DIR/$1
+	s3cmd --access_key=$ACCESS_KEY --secret_key=$SECRET_KEY --region=$REGION get $BUCKET$1 $DIR/$1
 
 	# Restore the DB
 	gunzip < $DIR/$1 | mysql -uroot -p$MYSQL_ENV_MYSQL_ROOT_PASSWORD -hmysql


### PR DESCRIPTION
Hi,
i've added the REGION env variable, with by default the 'us-east-1' region (default region in aws).
This variable is now always used by the s3cmd  command.
It solved my aws region problem which prevents database restoration.

best regards,
Charles. 
